### PR TITLE
Support sampling flag propagation

### DIFF
--- a/zipkin/src/lib.rs
+++ b/zipkin/src/lib.rs
@@ -52,6 +52,8 @@ pub use report::Report;
 #[doc(inline)]
 pub use sample::Sample;
 #[doc(inline)]
+pub use sampling_flags::SamplingFlags;
+#[doc(inline)]
 pub use span::{Kind, Span};
 #[doc(inline)]
 pub use span_id::SpanId;
@@ -66,6 +68,7 @@ pub mod annotation;
 pub mod endpoint;
 pub mod report;
 pub mod sample;
+pub mod sampling_flags;
 pub mod span;
 pub mod span_id;
 pub mod trace_context;

--- a/zipkin/src/sampling_flags.rs
+++ b/zipkin/src/sampling_flags.rs
@@ -1,0 +1,90 @@
+//  Copyright 2017 Palantir Technologies, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Sampling flags.
+
+/// Flags used to control sampling.
+#[derive(Debug, Copy, Clone)]
+pub struct SamplingFlags {
+    pub(crate) sampled: Option<bool>,
+    debug: bool,
+}
+
+impl Default for SamplingFlags {
+    fn default() -> SamplingFlags {
+        SamplingFlags::builder().build()
+    }
+}
+
+impl SamplingFlags {
+    /// Returns a builder used to construct `SamplingFlags`.
+    pub fn builder() -> Builder {
+        Builder {
+            sampled: None,
+            debug: false,
+        }
+    }
+
+    /// Determines if sampling has been requested for this context.
+    ///
+    /// A value of `None` indicates that the service working in the context is
+    /// responsible for determining if it should be sampled.
+    pub fn sampled(&self) -> Option<bool> {
+        self.sampled
+    }
+
+    /// Determines if this context is in debug mode.
+    ///
+    /// Debug contexts should always be sampled, regardless of the value of
+    /// `sampled()`.
+    pub fn debug(&self) -> bool {
+        self.debug
+    }
+}
+
+/// A builder type for `SamplingFlags`.
+pub struct Builder {
+    sampled: Option<bool>,
+    debug: bool,
+}
+
+impl Builder {
+    /// Sets the sampling request for this context.
+    ///
+    /// Defaults to `None`.
+    pub fn sampled(&mut self, sampled: bool) -> &mut Builder {
+        self.sampled = Some(sampled);
+        self
+    }
+
+    /// Sets the debug flag for this request.
+    ///
+    /// Defaults to `false`.
+    pub fn debug(&mut self, debug: bool) -> &mut Builder {
+        self.debug = debug;
+        self
+    }
+
+    /// Constructs `SamplingFlags`.
+    pub fn build(&self) -> SamplingFlags {
+        SamplingFlags {
+            sampled: if self.debug {
+                Some(true)
+            } else {
+                self.sampled
+            },
+            debug: self.debug,
+        }
+    }
+}

--- a/zipkin/src/sampling_flags.rs
+++ b/zipkin/src/sampling_flags.rs
@@ -59,6 +59,15 @@ pub struct Builder {
     debug: bool,
 }
 
+impl From<SamplingFlags> for Builder {
+    fn from(flags: SamplingFlags) -> Builder {
+        Builder {
+            sampled: flags.sampled,
+            debug: flags.debug,
+        }
+    }
+}
+
 impl Builder {
     /// Sets the sampling request for this context.
     ///

--- a/zipkin/src/trace_context.rs
+++ b/zipkin/src/trace_context.rs
@@ -55,6 +55,11 @@ impl TraceContext {
         self.span_id
     }
 
+    /// Returns the sampling flags associated with this context.
+    pub fn sampling_flags(&self) -> SamplingFlags {
+        self.flags
+    }
+
     /// Determines if sampling has been requested for this context.
     ///
     /// A value of `None` indicates that the service working in the context is
@@ -84,6 +89,12 @@ impl Builder {
     /// Defaults to `None`.
     pub fn parent_id(&mut self, parent_id: SpanId) -> &mut Builder {
         self.parent_id = Some(parent_id);
+        self
+    }
+
+    /// Sets the sampling flags for this context.
+    pub fn sampling_flags(&mut self, flags: SamplingFlags) -> &mut Builder {
+        self.flags = flags.into();
         self
     }
 

--- a/zipkin/src/tracer.rs
+++ b/zipkin/src/tracer.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 use thread_local_object::ThreadLocal;
 
-use {Annotation, Endpoint, Kind, Report, Sample, Span, SpanId, TraceContext, TraceId};
+use {Annotation, Endpoint, Kind, Report, Sample, SamplingFlags, Span, SpanId, TraceContext,
+     TraceId};
 use report::LoggingReporter;
 use sample::AlwaysSampler;
 use span;
@@ -152,7 +153,16 @@ impl Tracer {
 
     /// Starts a new trace with no parent.
     pub fn new_trace(&self) -> OpenSpan {
-        self.ensure_sampled(self.next_context(None, None, false), false)
+        self.new_trace_from(SamplingFlags::default())
+    }
+
+    /// Starts a new trace with no parent with specific sampling flags.
+    pub fn new_trace_from(&self, flags: SamplingFlags) -> OpenSpan {
+        let id = self.next_id();
+        let context = TraceContext::builder()
+            .sampling_flags(flags)
+            .build(TraceId::from(id), SpanId::from(id));
+        self.ensure_sampled(context, false)
     }
 
     /// Joins an existing trace.
@@ -164,7 +174,11 @@ impl Tracer {
 
     /// Starts a new span with the specified parent.
     pub fn new_child(&self, parent: TraceContext) -> OpenSpan {
-        let context = self.next_context(Some(parent), parent.sampled(), parent.debug());
+        let id = self.next_id();
+        let context = TraceContext::builder()
+            .parent_id(parent.span_id())
+            .sampling_flags(parent.sampling_flags())
+            .build(parent.trace_id(), SpanId::from(id));
         self.ensure_sampled(context, false)
     }
 
@@ -176,11 +190,17 @@ impl Tracer {
         }
     }
 
+    fn next_id(&self) -> [u8; 8] {
+        let mut id = [0; 8];
+        rand::thread_rng().fill_bytes(&mut id);
+        id
+    }
+
     fn ensure_sampled(&self, mut context: TraceContext, mut shared: bool) -> OpenSpan {
         if let None = context.sampled() {
             context.flags.sampled = Some(self.0.sampler.sample(context.trace_id()));
             // since the thing we got this context from didn't indicate if it should be sampled
-            // we can't assume they're recording the start/duration for us.
+            // we can't assume they're recording the span as well.
             shared = false;
         }
 
@@ -230,36 +250,6 @@ impl Tracer {
     /// Returns this thread's current trace context.
     pub fn current(&self) -> Option<TraceContext> {
         self.0.current.get_cloned()
-    }
-
-    fn next_context(
-        &self,
-        parent: Option<TraceContext>,
-        mut sampled: Option<bool>,
-        mut debug: bool,
-    ) -> TraceContext {
-        let mut id = [0; 8];
-        rand::thread_rng().fill_bytes(&mut id);
-
-        let mut context = TraceContext::builder();
-        let trace_id = match parent {
-            Some(parent) => {
-                context.parent_id(parent.span_id());
-                sampled = parent.sampled();
-                debug = parent.debug();
-
-                parent.trace_id()
-            }
-            None => TraceId::from(id),
-        };
-
-        context.debug(debug);
-        if let Some(sampled) = sampled {
-            context.sampled(sampled);
-        }
-
-        let span_id = SpanId::from(id);
-        context.build(trace_id, span_id)
     }
 }
 

--- a/zipkin/src/tracer.rs
+++ b/zipkin/src/tracer.rs
@@ -164,10 +164,6 @@ impl Tracer {
 
     /// Starts a new span with the specified parent.
     pub fn new_child(&self, parent: TraceContext) -> OpenSpan {
-        if parent.sampled() == Some(false) {
-            return self.new_span(parent, SpanState::Nop);
-        }
-
         let context = self.next_context(Some(parent), parent.sampled(), parent.debug());
         self.ensure_sampled(context, false)
     }

--- a/zipkin/src/tracer.rs
+++ b/zipkin/src/tracer.rs
@@ -182,7 +182,7 @@ impl Tracer {
 
     fn ensure_sampled(&self, mut context: TraceContext, mut shared: bool) -> OpenSpan {
         if let None = context.sampled() {
-            context.sampled = Some(self.0.sampler.sample(context.trace_id()));
+            context.flags.sampled = Some(self.0.sampler.sample(context.trace_id()));
             // since the thing we got this context from didn't indicate if it should be sampled
             // we can't assume they're recording the start/duration for us.
             shared = false;


### PR DESCRIPTION
Closes #7 

This doesn't support trace ID-only propagation but that's way more obscure.