### PR TITLE
Make it possible to instantiate OpenSpan directly

### DIFF
--- a/zipkin/src/tracer.rs
+++ b/zipkin/src/tracer.rs
@@ -26,7 +26,8 @@ use report::LoggingReporter;
 use sample::AlwaysSampler;
 use span;
 
-enum SpanState {
+#[doc(hidden)]
+pub enum SpanState {
     Real {
         span: span::Builder,
         start_instant: Instant,
@@ -86,6 +87,15 @@ impl Drop for OpenSpan {
 }
 
 impl OpenSpan {
+    /// A lower-level way to instantiate an `OpenSpan`, e.g. when producing API wrappers or bindings
+    /// for other languages.
+    /// Prefer Tracer API methods that instantiate spans (e.g. [new_trace](./struct.Tracer.html#method.new_trace)).
+    pub fn new(context: TraceContext, guard: CurrentGuard, state: SpanState) -> Self {
+        Self {
+            context, guard, state
+        }
+    }
+
     /// Returns the context associated with this span.
     pub fn context(&self) -> TraceContext {
         self.context


### PR DESCRIPTION
For the rare cases where it has to be done this way, e.g. when producing
wrapper libraries or interfacing with other programming languages
via bindings.

The docs encourage the user to use the public Tracer API.