### PR TITLE
Move required fields out of final builder methods.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     working_directory: ~/build
     docker:
-      - image: rust:1.21.0
+      - image: rust:1.25.0-slim
         environment:
           RUSTFLAGS: -D warnings
     steps:

--- a/zipkin/src/endpoint.rs
+++ b/zipkin/src/endpoint.rs
@@ -70,6 +70,17 @@ pub struct Builder {
     port: Option<u16>,
 }
 
+impl From<Endpoint> for Builder {
+    fn from(e: Endpoint) -> Builder {
+        Builder {
+            service_name: e.service_name,
+            ipv4: e.ipv4,
+            ipv6: e.ipv6,
+            port: e.port,
+        }
+    }
+}
+
 impl Builder {
     /// Sets the service name associated with the endpoint.
     ///

--- a/zipkin/src/sampling_flags.rs
+++ b/zipkin/src/sampling_flags.rs
@@ -15,7 +15,7 @@
 //! Sampling flags.
 
 /// Flags used to control sampling.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SamplingFlags {
     pub(crate) sampled: Option<bool>,
     debug: bool,


### PR DESCRIPTION
This introduces runtime failure modes, but improves things in other
ways. You can now convert a value back into a builder for example.