### PR TITLE
Refactor Report to take Spans by value

### DIFF
--- a/zipkin/src/report.rs
+++ b/zipkin/src/report.rs
@@ -21,14 +21,27 @@ use Span;
 /// it over the network to a collection service.
 pub trait Report {
     /// Reports a span.
-    fn report(&self, span: &Span);
+    ///
+    /// For backwards compatibility, the default implementation of this method
+    /// delegates to the deprecated `report` method. It should be overridden by
+    /// all implementations.
+    #[allow(deprecated)]
+    fn report2(&self, span: Span) {
+        self.report(&span);
+    }
+
+    #[allow(missing_docs)]
+    #[deprecated(since = "0.3.2", note = "use `report2` instead")]
+    fn report(&self, _: &Span) {
+        unimplemented!()
+    }
 }
 
 /// A `Report`er which does nothing.
 pub struct NopReporter;
 
 impl Report for NopReporter {
-    fn report(&self, _: &Span) {}
+    fn report2(&self, _: Span) {}
 }
 
 /// A `Report`er which logs the `Span` at the `info` level.
@@ -38,7 +51,7 @@ impl Report for NopReporter {
 pub struct LoggingReporter;
 
 impl Report for LoggingReporter {
-    fn report(&self, span: &Span) {
+    fn report2(&self, span: Span) {
         info!("{:?}", span);
     }
 }

--- a/zipkin/src/tracer.rs
+++ b/zipkin/src/tracer.rs
@@ -135,7 +135,7 @@ where
         } = mem::replace(&mut self.state, SpanState::Nop)
         {
             let span = span.duration(start_instant.elapsed()).build();
-            self.attachment.tracer().0.reporter.report(&span);
+            self.attachment.tracer().0.reporter.report2(span);
         }
     }
 }


### PR DESCRIPTION
This is strictly more flexible wrt e.g. sending the spans to a separate
thread, and we're not doing anything with the span after reporting it
anyway.

This makes the trait definition a bit weird but we can fix that in 0.4.