### PR TITLE
Drop the span on future completion, not drop

### DIFF
--- a/zipkin/Cargo.toml
+++ b/zipkin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zipkin"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
The old behavior interacted poorly with manually-written futures like this one in conjure-rust-runtime: https://github.com/palantir/conjure-rust-runtime/blob/master/conjure-runtime/src/service/span.rs#L71. The wait-for-headers span would end up terminating slightly *after* the wait-for-body span started which resulted in some annoying overlap in the rendering of the trace.

The new behavior should align more reasonably with what you'd expect.